### PR TITLE
Configure PHPUnit tests for Choices

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# Taken from https://github.com/WordPress/wordpress-develop/blob/master/.editorconfig
+# WordPress Coding Standards: https://make.wordpress.org/core/handbook/coding-standards/
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+vendor
+composer.lock
+phpunit.xml
+.phpunit.result.cache
+.php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,28 @@
 {
-  "name": "jmichaelward/gf-structures",
-  "description": "A class-based library to streamline working with Gravity Forms array entities.",
-  "type": "library",
-  "license": "GPL-3.0+",
-  "authors": [
-	{
-	  "name": "Jeremy Ward",
-	  "email": "jeremy@jmichaelward.com"
+	"name": "jmichaelward/gf-structures",
+	"description": "A class-based library to streamline working with Gravity Forms array entities.",
+	"type": "library",
+	"license": "GPL-3.0+",
+	"authors": [
+		{
+			"name": "Jeremy Ward",
+			"email": "jeremy@jmichaelward.com"
+		}
+	],
+	"require": {
+		"php": "^5.6 || ^7 || ^8"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9.5.4"
+	},
+	"autoload": {
+		"psr-4": {
+			"JMichaelWard\\GF_Structures\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"JMichaelWard\\GF_Structures\\Tests\\": "tests"
+		}
 	}
-  ],
-  "require": {
-	"php": "^5.6 || ^7 || ^8"
-  },
-  "require-dev": {
-	"phpunit/phpunit": "^9.5.4"
-  },
-  "autoload": {
-	"psr-4": {
-	  "JMichaelWard\\GF_Structures\\": "src/"
-	}
-  },
-  "autoload-dev": {
-	"psr-4": {
-	  "JMichaelWard\\GF_Structures\\Tests\\": "tests"
-	}
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,17 @@
     "require": {
 	    "php": "^5.6 || ^7 || ^8"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5.4"
+    },
 	"autoload": {
 		"psr-4": {
 			"JMichaelWard\\GF_Structures\\": "src/"
 		}
-	}
+	},
+    "autoload-dev": {
+        "psr-4": {
+            "JMichaelWard\\GF_Structures\\Tests\\": "tests"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,28 @@
 {
-    "name": "jmichaelward/gf-structures",
-    "description": "A class-based library to streamline working with Gravity Forms array entities.",
-    "type": "library",
-    "license": "GPL-3.0+",
-    "authors": [
-        {
-            "name": "Jeremy Ward",
-            "email": "jeremy@jmichaelward.com"
-        }
-    ],
-    "require": {
-	    "php": "^5.6 || ^7 || ^8"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^9.5.4"
-    },
-	"autoload": {
-		"psr-4": {
-			"JMichaelWard\\GF_Structures\\": "src/"
-		}
-	},
-    "autoload-dev": {
-        "psr-4": {
-            "JMichaelWard\\GF_Structures\\Tests\\": "tests"
-        }
-    }
+  "name": "jmichaelward/gf-structures",
+  "description": "A class-based library to streamline working with Gravity Forms array entities.",
+  "type": "library",
+  "license": "GPL-3.0+",
+  "authors": [
+	{
+	  "name": "Jeremy Ward",
+	  "email": "jeremy@jmichaelward.com"
+	}
+  ],
+  "require": {
+	"php": "^5.6 || ^7 || ^8"
+  },
+  "require-dev": {
+	"phpunit/phpunit": "^9.5.4"
+  },
+  "autoload": {
+	"psr-4": {
+	  "JMichaelWard\\GF_Structures\\": "src/"
+	}
+  },
+  "autoload-dev": {
+	"psr-4": {
+	  "JMichaelWard\\GF_Structures\\Tests\\": "tests"
+	}
+  }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="GF_Structures Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
+		 backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true"
+		 convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false"
+		 stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+	<coverage>
+		<include>
+			<directory suffix=".php">src/</directory>
+		</include>
+	</coverage>
+	<testsuites>
+		<testsuite name="GF_Structures Test Suite">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="GF_Structures Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Settings/ChoiceTest.php
+++ b/tests/Settings/ChoiceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace JMichaelWard\GF_Structures\Tests\Settings;
+
+use JMichaelWard\GF_Structures\Settings\Choice;
+use PHPUnit\Framework\TestCase;
+
+class ChoiceTest extends TestCase
+{
+    public function testDefaults()
+    {
+        $choice = new Choice('Test');
+        $this->assertEquals(
+            array('label' => 'Test'),
+            $choice->get_as_array()
+        );
+    }
+
+    public function testLabelIsRequired()
+    {
+        $this->expectException(\TypeError::class);
+        new Choice();
+
+        $emptyLabel = new Choice('');
+        $this->expectEquals('', $emptyLabel->get_as_array()['label']);
+    }
+
+    public function testSetName()
+    {
+        $choice = new Choice('Test Choice');
+
+        $this->assertArrayNotHasKey('name', $choice->get_as_array());
+
+        $this->expectException(\TypeError::class);
+        $choice->set_name(null);
+
+        $choice->set_name('testchoice');
+        $this->assertArrayHasKey('name', $choice->get_as_array());
+        $this->assertEquals('testchoice', $choice->get_as_array()['name']);
+    }
+
+    public function testFluentInterface()
+    {
+        $choice = new Choice('test label');
+
+        $this->assertSame($choice, $choice->set_choices(array()));
+        $this->assertSame($choice, $choice->set_default_value(1));
+        $this->assertSame($choice, $choice->set_icon('icon'));
+        $this->assertSame($choice, $choice->set_name('choice name'));
+        $this->assertSame($choice, $choice->set_tooltip('tooltip'));
+        $this->assertSame($choice, $choice->set_tooltip_class('class'));
+        $this->assertSame($choice, $choice->set_value('value'));
+    }
+}

--- a/tests/Settings/ChoiceTest.php
+++ b/tests/Settings/ChoiceTest.php
@@ -4,51 +4,52 @@ namespace JMichaelWard\GF_Structures\Tests\Settings;
 
 use JMichaelWard\GF_Structures\Settings\Choice;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 class ChoiceTest extends TestCase
 {
-    public function testDefaults()
-    {
-        $choice = new Choice('Test');
-        $this->assertEquals(
-            array('label' => 'Test'),
-            $choice->get_as_array()
-        );
-    }
+	public function testDefaults()
+	{
+		$choice = new Choice('Test');
+		$this->assertEquals(
+			array('label' => 'Test'),
+			$choice->get_as_array()
+		);
+	}
 
-    public function testLabelIsRequired()
-    {
-        $this->expectException(\TypeError::class);
-        new Choice();
+	public function testLabelIsRequired()
+	{
+		$this->expectException(TypeError::class);
+		new Choice();
 
-        $emptyLabel = new Choice('');
-        $this->expectEquals('', $emptyLabel->get_as_array()['label']);
-    }
+		$emptyLabel = new Choice('');
+		$this->expectEquals('', $emptyLabel->get_as_array()['label']);
+	}
 
-    public function testSetName()
-    {
-        $choice = new Choice('Test Choice');
+	public function testSetName()
+	{
+		$choice = new Choice('Test Choice');
 
-        $this->assertArrayNotHasKey('name', $choice->get_as_array());
+		$this->assertArrayNotHasKey('name', $choice->get_as_array());
 
-        $this->expectException(\TypeError::class);
-        $choice->set_name(null);
+		$this->expectException(TypeError::class);
+		$choice->set_name(null);
 
-        $choice->set_name('testchoice');
-        $this->assertArrayHasKey('name', $choice->get_as_array());
-        $this->assertEquals('testchoice', $choice->get_as_array()['name']);
-    }
+		$choice->set_name('testchoice');
+		$this->assertArrayHasKey('name', $choice->get_as_array());
+		$this->assertEquals('testchoice', $choice->get_as_array()['name']);
+	}
 
-    public function testFluentInterface()
-    {
-        $choice = new Choice('test label');
+	public function testFluentInterface()
+	{
+		$choice = new Choice('test label');
 
-        $this->assertSame($choice, $choice->set_choices(array()));
-        $this->assertSame($choice, $choice->set_default_value(1));
-        $this->assertSame($choice, $choice->set_icon('icon'));
-        $this->assertSame($choice, $choice->set_name('choice name'));
-        $this->assertSame($choice, $choice->set_tooltip('tooltip'));
-        $this->assertSame($choice, $choice->set_tooltip_class('class'));
-        $this->assertSame($choice, $choice->set_value('value'));
-    }
+		$this->assertSame($choice, $choice->set_choices(array()));
+		$this->assertSame($choice, $choice->set_default_value(1));
+		$this->assertSame($choice, $choice->set_icon('icon'));
+		$this->assertSame($choice, $choice->set_name('choice name'));
+		$this->assertSame($choice, $choice->set_tooltip('tooltip'));
+		$this->assertSame($choice, $choice->set_tooltip_class('class'));
+		$this->assertSame($choice, $choice->set_value('value'));
+	}
 }

--- a/tests/Settings/ChoiceTest.php
+++ b/tests/Settings/ChoiceTest.php
@@ -20,7 +20,7 @@ class ChoiceTest extends TestCase
 	public function testLabelIsRequired()
 	{
 		$this->expectException(TypeError::class);
-		new Choice();
+		new Choice(null);
 	}
 
 	public function testLabelMustBeString()

--- a/tests/Settings/ChoiceTest.php
+++ b/tests/Settings/ChoiceTest.php
@@ -21,9 +21,26 @@ class ChoiceTest extends TestCase
 	{
 		$this->expectException(TypeError::class);
 		new Choice();
+	}
 
-		$emptyLabel = new Choice('');
-		$this->expectEquals('', $emptyLabel->get_as_array()['label']);
+	public function testLabelMustBeString()
+	{
+		$this->expectException(TypeError::class);
+		new Choice(1);
+	}
+
+	public function testLabelCannotBeEmpty()
+	{
+		$choice = new Choice('');
+		$this->assertEquals(array(), $choice->get_as_array());
+	}
+
+	public function testNameCannotBeNull()
+	{
+		$choice = new Choice('Test Choice');
+
+		$this->expectException(TypeError::class);
+		$choice->set_name(null);
 	}
 
 	public function testSetName()
@@ -31,9 +48,6 @@ class ChoiceTest extends TestCase
 		$choice = new Choice('Test Choice');
 
 		$this->assertArrayNotHasKey('name', $choice->get_as_array());
-
-		$this->expectException(TypeError::class);
-		$choice->set_name(null);
 
 		$choice->set_name('testchoice');
 		$this->assertArrayHasKey('name', $choice->get_as_array());

--- a/tests/Settings/FieldTest.php
+++ b/tests/Settings/FieldTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace JMichaelWard\GF_Structures\Tests\Settings;
+
+use JMichaelWard\GF_Structures\Settings\Field;
+use PHPUnit\Framework\TestCase;
+
+class FieldTest extends TestCase
+{
+	protected $mockCallable;
+
+	public function testTypeParameterMustBeString()
+	{
+		$this->expectException(\TypeError::class);
+		new Field(array(), 'Name');
+	}
+
+	public function testNameParameterMustBeString()
+	{
+		$this->expectException(\TypeError::class);
+		new Field('Type', 42);
+	}
+
+    public function testGetAsArray()
+    {
+    	$this->markTestSkipped('Skipping because using array_filter removes falsey-valued properties');
+
+    	$expectedValues = array(
+			'type'                => Field\FieldType::TEXT,
+			'input_type'          => 'Input Type',
+			'name'                => 'Text Field',
+			'id'                  => 'ID',
+			'label'               => 'Label',
+			'required'            => true,
+			'class'               => 'Class',
+			'hidden'              => false,
+			'default_value'       => 'Default Value',
+			'horizontal'          => false,
+			//'dependency'          => $this->dependency,
+			//'choices'             => $this->get_choices_as_array(),
+			'feedback_callback'   => $this->getFakeCallback(),
+			'callback'            => $this->getFakeCallback(),
+			'validation_callback' => $this->getFakeCallback(),
+			'after_input'         => 'After Input',
+			//'field_map'           => $this->field_map,
+		);
+
+    	$field = (new Field($expectedValues['type'], $expectedValues['name']))
+			->set_input_type($expectedValues['input_type'])
+			->set_id($expectedValues['id'])
+			->set_label($expectedValues['label'])
+			->set_required($expectedValues['required'])
+			->set_class($expectedValues['class'])
+			->set_hidden($expectedValues['hidden'])
+			->set_default_value($expectedValues['default_value'])
+			->set_horizontal($expectedValues['horizontal'])
+			->set_feedback_callback($expectedValues['feedback_callback'])
+			->set_callback($expectedValues['callback'])
+			->set_validation_callback($expectedValues['validation_callback'])
+			->set_after_input($expectedValues['after_input']);
+
+    	$this->assertEquals($expectedValues, $field->get_as_array());
+    }
+
+    protected function getFakeCallback()
+	{
+		if ( is_null( $this->mockCallable ) ) {
+			$this->mockCallable = $this->getMockBuilder(\stdClass::class)->addMethods(['__invoke'])->getMock();
+		}
+
+		return $this->mockCallable;
+	}
+}

--- a/tests/Settings/HasChoicesTest.php
+++ b/tests/Settings/HasChoicesTest.php
@@ -4,61 +4,62 @@ namespace JMichaelWard\GF_Structures\Tests\Settings;
 
 use JMichaelWard\GF_Structures\Settings\Choice\ChoiceInterface;
 use JMichaelWard\GF_Structures\Settings\HasChoices;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class HasChoicesTest extends TestCase
 {
-    public function testAddIndividualChoices()
-    {
-        $classWithChoices = $this->getClassWithChoices();
+	public function testAddIndividualChoices()
+	{
+		$classWithChoices = $this->getClassWithChoices();
 
-        $this->assertEmpty($classWithChoices->get_choices_as_array());
+		$this->assertEmpty($classWithChoices->get_choices_as_array());
 
-        $choiceStub = $this->getChoiceStub('choice stub');
-        $classWithChoices->add_choice($choiceStub);
-        $this->assertCount(1, $classWithChoices->get_choices_as_array());
-        $this->assertEquals(
-            array(array('label' => 'choice stub')),
-            $classWithChoices->get_choices_as_array()
-        );
-    }
+		$choiceStub = $this->getChoiceStub('choice stub');
+		$classWithChoices->add_choice($choiceStub);
+		$this->assertCount(1, $classWithChoices->get_choices_as_array());
+		$this->assertEquals(
+			array(array('label' => 'choice stub')),
+			$classWithChoices->get_choices_as_array()
+		);
+	}
 
-    public function testAddChoicesAsArray()
-    {
-        $classWithChoices = $this->getClassWithChoices();
+	public function testAddChoicesAsArray()
+	{
+		$classWithChoices = $this->getClassWithChoices();
 
-        $choices = array(
-            $this->getChoiceStub('choice1'),
-            $this->getChoiceStub('choice2')
-        );
+		$choices = array(
+			$this->getChoiceStub('choice1'),
+			$this->getChoiceStub('choice2')
+		);
 
-        $classWithChoices->set_choices($choices);
-        $this->assertCount(2, $classWithChoices->get_choices_as_array());
-        $this->assertEquals(
-            array(
-                array('label' => 'choice1'),
-                array('label' => 'choice2'),
-            ),
-            $classWithChoices->get_choices_as_array()
-        );
-    }
+		$classWithChoices->set_choices($choices);
+		$this->assertCount(2, $classWithChoices->get_choices_as_array());
+		$this->assertEquals(
+			array(
+				array('label' => 'choice1'),
+				array('label' => 'choice2'),
+			),
+			$classWithChoices->get_choices_as_array()
+		);
+	}
 
-    /**
-     * @return ChoiceInterface|\PHPUnit\Framework\MockObject\Stub
-     */
-    protected function getChoiceStub($label): ChoiceInterface|\PHPUnit\Framework\MockObject\Stub
-    {
-        $choiceStub = $this->createStub(ChoiceInterface::class);
-        $choiceStub->method('get_as_array')
-            ->willReturn(array('label' => $label));
+	/**
+	 * @return ChoiceInterface|Stub
+	 */
+	protected function getChoiceStub($label): ChoiceInterface|Stub
+	{
+		$choiceStub = $this->createStub(ChoiceInterface::class);
+		$choiceStub->method('get_as_array')
+			->willReturn(array('label' => $label));
 
-        return $choiceStub;
-    }
+		return $choiceStub;
+	}
 
-    protected function getClassWithChoices()
-    {
-        return new class() {
-            use HasChoices;
-        };
-    }
+	protected function getClassWithChoices()
+	{
+		return new class() {
+			use HasChoices;
+		};
+	}
 }

--- a/tests/Settings/HasChoicesTest.php
+++ b/tests/Settings/HasChoicesTest.php
@@ -4,7 +4,6 @@ namespace JMichaelWard\GF_Structures\Tests\Settings;
 
 use JMichaelWard\GF_Structures\Settings\Choice\ChoiceInterface;
 use JMichaelWard\GF_Structures\Settings\HasChoices;
-use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class HasChoicesTest extends TestCase
@@ -45,9 +44,9 @@ class HasChoicesTest extends TestCase
 	}
 
 	/**
-	 * @return ChoiceInterface|Stub
+	 * @return ChoiceInterface
 	 */
-	protected function getChoiceStub($label): ChoiceInterface|Stub
+	protected function getChoiceStub($label): ChoiceInterface
 	{
 		$choiceStub = $this->createStub(ChoiceInterface::class);
 		$choiceStub->method('get_as_array')

--- a/tests/Settings/HasChoicesTest.php
+++ b/tests/Settings/HasChoicesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace JMichaelWard\GF_Structures\Tests\Settings;
+
+use JMichaelWard\GF_Structures\Settings\Choice\ChoiceInterface;
+use JMichaelWard\GF_Structures\Settings\HasChoices;
+use PHPUnit\Framework\TestCase;
+
+class HasChoicesTest extends TestCase
+{
+    public function testAddIndividualChoices()
+    {
+        $classWithChoices = $this->getClassWithChoices();
+
+        $this->assertEmpty($classWithChoices->get_choices_as_array());
+
+        $choiceStub = $this->getChoiceStub('choice stub');
+        $classWithChoices->add_choice($choiceStub);
+        $this->assertCount(1, $classWithChoices->get_choices_as_array());
+        $this->assertEquals(
+            array(array('label' => 'choice stub')),
+            $classWithChoices->get_choices_as_array()
+        );
+    }
+
+    public function testAddChoicesAsArray()
+    {
+        $classWithChoices = $this->getClassWithChoices();
+
+        $choices = array(
+            $this->getChoiceStub('choice1'),
+            $this->getChoiceStub('choice2')
+        );
+
+        $classWithChoices->set_choices($choices);
+        $this->assertCount(2, $classWithChoices->get_choices_as_array());
+        $this->assertEquals(
+            array(
+                array('label' => 'choice1'),
+                array('label' => 'choice2'),
+            ),
+            $classWithChoices->get_choices_as_array()
+        );
+    }
+
+    /**
+     * @return ChoiceInterface|\PHPUnit\Framework\MockObject\Stub
+     */
+    protected function getChoiceStub($label): ChoiceInterface|\PHPUnit\Framework\MockObject\Stub
+    {
+        $choiceStub = $this->createStub(ChoiceInterface::class);
+        $choiceStub->method('get_as_array')
+            ->willReturn(array('label' => $label));
+
+        return $choiceStub;
+    }
+
+    protected function getClassWithChoices()
+    {
+        return new class() {
+            use HasChoices;
+        };
+    }
+}

--- a/tests/Settings/HasTooltipTest.php
+++ b/tests/Settings/HasTooltipTest.php
@@ -2,38 +2,59 @@
 
 namespace JMichaelWard\GF_Structures\Tests\Settings;
 
+use JMichaelWard\GF_Structures\ArrayFormattable;
 use JMichaelWard\GF_Structures\Settings\HasTooltip;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
 class HasTooltipTest extends TestCase
 {
-	public function testGetSetTooltip()
+	public function testTooltipIsRequired()
 	{
 		$classWithTooltip = $this->getClassWithTooltip();
 
 		$this->expectException(TypeError::class);
 		$classWithTooltip->set_tooltip(null);
+	}
 
-		$classWithTooltip->set_tooltip('tooltip');
-		$this->assertEquals('tooltip', $classWithTooltip->get_tooltip());
+	public function testGetSetTooltip()
+	{
+		$classWithTooltip = $this->getClassWithTooltip();
+
+		$classWithTooltip->set_tooltip('test_tooltip');
+		$this->assertEquals('test_tooltip', $classWithTooltip->get_as_array()['tooltip']);
+	}
+
+	public function testTooltipClassIsRequired()
+	{
+		$classWithTooltip = $this->getClassWithTooltip();
+
+		$this->expectException(TypeError::class);
+		$classWithTooltip->set_tooltip_class(null);
 	}
 
 	public function testGetSetTooltipClass()
 	{
 		$classWithTooltip = $this->getClassWithTooltip();
 
-		$this->expectException(TypeError::class);
-		$classWithTooltip->set_tooltip_class(null);
-
-		$classWithTooltip->set_tooltip_class('tooltip_class');
-		$this->assertEquals('tooltip_class', $classWithTooltip->get_tooltip_class());
+		$classWithTooltip->set_tooltip_class('test_tooltip_class');
+		$this->assertEquals('test_tooltip_class', $classWithTooltip->get_as_array()['tooltip_class']);
 	}
 
 	protected function getClassWithTooltip()
 	{
-		return new class() {
+		return new class() implements ArrayFormattable {
 			use HasTooltip;
+
+			public function get_as_array()
+			{
+				return array_filter(
+					array(
+						'tooltip'       => $this->get_tooltip(),
+						'tooltip_class' => $this->get_tooltip_class(),
+					)
+				);
+			}
 		};
 	}
 }

--- a/tests/Settings/HasTooltipTest.php
+++ b/tests/Settings/HasTooltipTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace JMichaelWard\GF_Structures\Tests\Settings;
+
+use JMichaelWard\GF_Structures\Settings\HasTooltip;
+use PHPUnit\Framework\TestCase;
+
+class HasTooltipTest extends TestCase
+{
+    public function testGetSetTooltip()
+    {
+        $classWithTooltip = $this->getClassWithTooltip();
+
+        $this->expectException(\TypeError::class);
+        $classWithTooltip->set_tooltip(null);
+
+        $classWithTooltip->set_tooltip('tooltip');
+        $this->assertEquals('tooltip', $classWithTooltip->get_tooltip());
+    }
+
+    public function testGetSetTooltipClass()
+    {
+        $classWithTooltip = $this->getClassWithTooltip();
+
+        $this->expectException(\TypeError::class);
+        $classWithTooltip->set_tooltip_class(null);
+
+        $classWithTooltip->set_tooltip_class('tooltip_class');
+        $this->assertEquals('tooltip_class', $classWithTooltip->get_tooltip_class());
+    }
+
+    protected function getClassWithTooltip()
+    {
+        return new class() {
+            use HasTooltip;
+        };
+    }
+}

--- a/tests/Settings/HasTooltipTest.php
+++ b/tests/Settings/HasTooltipTest.php
@@ -4,35 +4,36 @@ namespace JMichaelWard\GF_Structures\Tests\Settings;
 
 use JMichaelWard\GF_Structures\Settings\HasTooltip;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 class HasTooltipTest extends TestCase
 {
-    public function testGetSetTooltip()
-    {
-        $classWithTooltip = $this->getClassWithTooltip();
+	public function testGetSetTooltip()
+	{
+		$classWithTooltip = $this->getClassWithTooltip();
 
-        $this->expectException(\TypeError::class);
-        $classWithTooltip->set_tooltip(null);
+		$this->expectException(TypeError::class);
+		$classWithTooltip->set_tooltip(null);
 
-        $classWithTooltip->set_tooltip('tooltip');
-        $this->assertEquals('tooltip', $classWithTooltip->get_tooltip());
-    }
+		$classWithTooltip->set_tooltip('tooltip');
+		$this->assertEquals('tooltip', $classWithTooltip->get_tooltip());
+	}
 
-    public function testGetSetTooltipClass()
-    {
-        $classWithTooltip = $this->getClassWithTooltip();
+	public function testGetSetTooltipClass()
+	{
+		$classWithTooltip = $this->getClassWithTooltip();
 
-        $this->expectException(\TypeError::class);
-        $classWithTooltip->set_tooltip_class(null);
+		$this->expectException(TypeError::class);
+		$classWithTooltip->set_tooltip_class(null);
 
-        $classWithTooltip->set_tooltip_class('tooltip_class');
-        $this->assertEquals('tooltip_class', $classWithTooltip->get_tooltip_class());
-    }
+		$classWithTooltip->set_tooltip_class('tooltip_class');
+		$this->assertEquals('tooltip_class', $classWithTooltip->get_tooltip_class());
+	}
 
-    protected function getClassWithTooltip()
-    {
-        return new class() {
-            use HasTooltip;
-        };
-    }
+	protected function getClassWithTooltip()
+	{
+		return new class() {
+			use HasTooltip;
+		};
+	}
 }

--- a/tests/Settings/PageTest.php
+++ b/tests/Settings/PageTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace JMichaelWard\GF_Structures\Tests\Settings;
+
+use JMichaelWard\GF_Structures\Settings\Choice;
+use JMichaelWard\GF_Structures\Settings\Field;
+use JMichaelWard\GF_Structures\Settings\Page;
+use JMichaelWard\GF_Structures\Settings\Section;
+use PHPUnit\Framework\TestCase;
+
+class PageTest extends TestCase
+{
+    public function testBuildFullPageSettings()
+    {
+    	$page = (new Page())
+			->add_section(
+				(new Section())
+					->set_title('Title for Section 1')
+					->set_description('Description for section 1')
+					->add_field(
+						(new Field(Field\FieldType::TEXT, 'mytext'))
+							->set_label('This is a text input')
+					)
+					->add_field(
+						(new Field(Field\FieldType::SELECT, 'myselect'))
+							->set_label('This is a select')
+							->set_choices(array(
+								(new Choice('my first choice'))->set_value('1'),
+								(new Choice('my second choice'))->set_value('2'),
+							))
+					)
+			);
+
+    	$this->assertEquals(
+    		array(
+    			array(
+    				'title' => 'Title for Section 1',
+					'description' => 'Description for section 1',
+					'fields' => array(
+						array(
+							'type' => 'text',
+							'label' => 'This is a text input',
+							'name' => 'mytext',
+						),
+						array(
+							'type' => 'select',
+							'label' => 'This is a select',
+							'name' => 'myselect',
+							'choices' => array(
+								array('label' => 'my first choice', 'value' => '1'),
+								array('label' => 'my second choice', 'value' => '2'),
+							)
+						)
+					)
+				)
+			),
+			$page->get_as_array()
+		);
+    }
+}

--- a/tests/Settings/SectionTest.php
+++ b/tests/Settings/SectionTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace JMichaelWard\GF_Structures\Tests\Settings;
+
+use JMichaelWard\GF_Structures\Settings\Field;
+use JMichaelWard\GF_Structures\Settings\Section;
+use PHPUnit\Framework\TestCase;
+
+class SectionTest extends TestCase
+{
+	protected Section $section;
+
+	protected function setUp(): void
+	{
+		$this->section = new Section();
+	}
+
+    public function testSetTitleMustBeString()
+    {
+    	$this->expectException(\TypeError::class);
+    	$this->section->set_title(1);
+    }
+
+    public function testSettableProperties()
+	{
+		$expectedValues = array(
+			'title'       => 'Test Title',
+			'description' => 'Test Description',
+			'id'          => 'Test Id',
+			'class'       => 'Test Class',
+			'style'       => 'Test Style',
+		);
+
+		$this->section
+			->set_title($expectedValues['title'])
+			->set_description($expectedValues['description'])
+			->set_id($expectedValues['id'])
+			->set_class($expectedValues['class'])
+			->set_style($expectedValues['style']);
+
+		$this->assertEquals(
+			$expectedValues,
+			$this->section->get_as_array()
+		);
+	}
+
+    public function testSetFieldsAsArray()
+    {
+    	$fieldsToSet = array(
+    		$this->createFieldStub(Field\FieldType::HIDDEN, 'Hidden Field'),
+			$this->createFieldStub(Field\FieldType::TEXT, 'Text Field'),
+		);
+
+    	$this->assertArrayNotHasKey('fields', $this->section->get_as_array());
+
+    	$this->section->set_fields($fieldsToSet);
+    	$this->assertArrayHasKey('fields', $this->section->get_as_array());
+    	$this->assertEquals(
+    		array(
+				'fields' => array(
+					array('type' => Field\FieldType::HIDDEN, 'name' => 'Hidden Field'),
+					array('type' => Field\FieldType::TEXT, 'name' => 'Text Field'),
+				),
+			),
+			$this->section->get_as_array()
+		);
+    }
+
+    public function testSetFieldsOverwriteExistingFields()
+	{
+		$this->section->add_field($this->createFieldStub(Field\FieldType::TEXT, 'Existing Field'));
+		$this->assertEquals(
+			array(
+				'fields' => array(
+					array('type' => Field\FieldType::TEXT, 'name' => 'Existing Field'),
+				),
+			),
+			$this->section->get_as_array()
+		);
+
+		$this->section->set_fields(array(
+			$this->createFieldStub(Field\FieldType::TEXT, 'New Field'),
+		));
+		$this->assertEquals(
+			array(
+				'fields' => array(
+					array('type' => Field\FieldType::TEXT, 'name' => 'New Field'),
+				),
+			),
+			$this->section->get_as_array()
+		);
+	}
+
+    public function testAddFieldIndividually()
+    {
+		$fieldStub = $this->createFieldStub(Field\FieldType::TEXT, 'Test Field');
+
+		$this->section->add_field($fieldStub);
+
+    	$this->assertEquals(
+    		array(
+    			'fields' => array(
+    				array(
+    					'type' => Field\FieldType::TEXT,
+						'name' => 'Test Field',
+					)
+				)
+			),
+			$this->section->get_as_array()
+		);
+    }
+
+	protected function createFieldStub($type, $name)
+	{
+		$fieldStub = $this->createStub(Field::class);
+		$fieldStub->method('get_as_array')
+			->willReturn(array(
+				'type' => $type,
+				'name' => $name,
+			));
+
+		return $fieldStub;
+	}
+}


### PR DESCRIPTION
Adds configuration for unit testing with PHPUnit and sets up a few base tests to start exercising the API. I thought this might be a good way to explore how the interface could be improved by looking at how it is used.

A couple of notes:

1. I assumed given PHP8 is in the composer.json file I can use it for dev tools and thus went with latest version of PHPUnit
2. Related, there is use of `\TypeError` to deal with validation. That was added in PHP7 but the composer.json specs allowable versions down to 5.6
3. I did not test the error handling too deeply for messages etc